### PR TITLE
Add cstring library to registrar.cpp

### DIFF
--- a/executeApp/src/registrar.cpp
+++ b/executeApp/src/registrar.cpp
@@ -30,6 +30,7 @@
 #include <regex>
 #include <stdexcept>
 #include <string>
+#include <cstring>
 
 extern "C" {
 #include <epicsExport.h>

--- a/executeApp/src/registrar.cpp
+++ b/executeApp/src/registrar.cpp
@@ -27,10 +27,10 @@
  * of the GNU LGPL version 3 or newer.
  */
 
+#include <cstring>
 #include <regex>
 #include <stdexcept>
 #include <string>
-#include <cstring>
 
 extern "C" {
 #include <epicsExport.h>


### PR DESCRIPTION
This is needed to avoid `error: ‘strlen’ is not a member of ‘std’; did you mean ‘mbrlen’?` error.