### PR TITLE
Use thread pool and close unused file descriptors in child processes

### DIFF
--- a/executeApp/src/Command.h
+++ b/executeApp/src/Command.h
@@ -1,6 +1,6 @@
 /*
- * Copyright 2018-2022 aquenos GmbH.
- * Copyright 2018-2022 Karlsruhe Institute of Technology.
+ * Copyright 2018-2023 aquenos GmbH.
+ * Copyright 2018-2023 Karlsruhe Institute of Technology.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -185,7 +185,6 @@ private:
   std::map<int, std::string> arguments;
   std::map<std::string, std::string> envVars;
   mutable std::mutex mutex;
-  std::forward_list<std::future<void>> pendingFutures;
   bool running;
   std::vector<char> stderrBuffer;
   std::size_t stderrCapacity;

--- a/executeApp/src/Makefile
+++ b/executeApp/src/Makefile
@@ -33,6 +33,7 @@ endif
 execute_SRCS += Command.cpp
 execute_SRCS += CommandRegistry.cpp
 execute_SRCS += RecordAddress.cpp
+execute_SRCS += ThreadPoolExecutor.cpp
 execute_SRCS += errorPrint.cpp
 execute_SRCS += recordDeviceSupportDefinitions.cpp
 execute_SRCS += registrar.cpp

--- a/executeApp/src/RunDeviceSupport.h
+++ b/executeApp/src/RunDeviceSupport.h
@@ -43,6 +43,7 @@ extern "C" {
 } // extern "C"
 
 #include "BaseDeviceSupport.h"
+#include "ThreadPoolExecutor.h"
 
 namespace epics {
 namespace execute {
@@ -156,7 +157,7 @@ public:
       // within this method, and calls of this method are synchronized through
       // other means, so we can use a relaxed memory order.
       runComplete.store(false, std::memory_order_relaxed);
-      asyncExecutionFuture = std::async(std::launch::async, [this]() {
+      asyncExecutionFuture = sharedThreadPoolExecutor().submit([this]() {
         try {
           this->getCommand()->run();
         } catch (...) {

--- a/executeApp/src/ThreadPoolExecutor.cpp
+++ b/executeApp/src/ThreadPoolExecutor.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 aquenos GmbH.
+ * Copyright 2023 Karlsruhe Institute of Technology.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * This software has been developed by aquenos GmbH on behalf of the
+ * Karlsruhe Institute of Technology's Institute for Beam Physics and
+ * Technology.
+ *
+ * This software contains code originally developed by aquenos GmbH for
+ * the s7nodave EPICS device support. aquenos GmbH has relicensed the
+ * affected portions of code from the s7nodave EPICS device support
+ * (originally licensed under the terms of the GNU GPL) under the terms
+ * of the GNU LGPL version 3 or newer.
+ */
+
+#include "ThreadPoolExecutor.h"
+
+namespace epics {
+namespace execute {
+
+ThreadPoolExecutor::ThreadPoolExecutor(
+  int maximumNumberOfIdleThreads
+) : sharedState(std::make_shared<SharedState>()) {
+  this->sharedState->idleThreads = 0;
+  this->sharedState->maxIdleThreads = maximumNumberOfIdleThreads;
+  this->sharedState->shutdown = false;
+}
+
+ThreadPoolExecutor::~ThreadPoolExecutor() {
+  {
+    std::lock_guard<std::mutex> lock(this->sharedState->mutex);
+    this->sharedState->shutdown = true;
+  }
+  this->sharedState->wakeUpCv.notify_all();
+}
+
+void ThreadPoolExecutor::processTasks(
+  std::shared_ptr<ThreadPoolExecutor::SharedState> sharedState
+) {
+  // This method is called in each one of the executor threads.
+  std::unique_lock<std::mutex> lock(sharedState->mutex);
+  while (true) {
+    if (sharedState->pendingTasks.empty()) {
+      if (sharedState->shutdown) {
+        --sharedState->idleThreads;
+        break;
+      }
+      sharedState->wakeUpCv.wait(lock);
+      continue;
+    }
+    auto task = std::move(sharedState->pendingTasks.front());
+    sharedState->pendingTasks.pop_front();
+    lock.unlock();
+    task();
+    lock.lock();
+    if (sharedState->idleThreads == sharedState->maxIdleThreads) {
+      break;
+    }
+    ++sharedState->idleThreads;
+  }
+}
+
+namespace {
+  ThreadPoolExecutor sharedExecutor(4);
+} // anonymous namespace
+
+ThreadPoolExecutor &sharedThreadPoolExecutor() {
+  return sharedExecutor;
+}
+
+} // namespace execute
+} // namespace epics

--- a/executeApp/src/ThreadPoolExecutor.h
+++ b/executeApp/src/ThreadPoolExecutor.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2023 aquenos GmbH.
+ * Copyright 2023 Karlsruhe Institute of Technology.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * This software has been developed by aquenos GmbH on behalf of the
+ * Karlsruhe Institute of Technology's Institute for Beam Physics and
+ * Technology.
+ *
+ * This software contains code originally developed by aquenos GmbH for
+ * the s7nodave EPICS device support. aquenos GmbH has relicensed the
+ * affected portions of code from the s7nodave EPICS device support
+ * (originally licensed under the terms of the GNU GPL) under the terms
+ * of the GNU LGPL version 3 or newer.
+ */
+
+#ifndef EPICS_EXEC_THREAD_POOL_EXECUTOR_H
+#define EPICS_EXEC_THREAD_POOL_EXECUTOR_H
+
+#include <condition_variable>
+#include <functional>
+#include <future>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <type_traits>
+#include <utility>
+
+namespace epics {
+namespace execute {
+
+/**
+ * Executor that runs tasks in separate threads, using a thread pool.
+ */
+class ThreadPoolExecutor {
+
+public:
+
+  /**
+   * Creates a thread pool that keeps up to the specified number of idle
+   * threads. More threads might still be created on demand.
+   */
+  ThreadPoolExecutor(int maximumNumberOfIdleThreads);
+
+  /**
+   * Destructor. When the destructor is called, no new submissions are allowed.
+   * The destructor does not wait for pending tasks to complete. Those tasks
+   * are going to complete in the background after the executor has been
+   * destructed.
+   */
+  ~ThreadPoolExecutor();
+
+  /**
+   * Submits a task for execution. The submitted task is executed in a thread
+   * of its own. If possible, an existing thread is reused. Otherwise, a new
+   * thread is created.
+   */
+  template<class Function, class... Args>
+  std::future<
+    typename std::result_of<
+      typename std::decay<Function>::type(typename std::decay<Args>::type...)
+    >::type
+  > submit(Function &&f, Args &&... args);
+
+private:
+
+  struct SharedState {
+    int idleThreads;
+    int maxIdleThreads;
+    std::mutex mutex;
+    std::list<std::function<void()>> pendingTasks;
+    bool shutdown;
+    std::condition_variable wakeUpCv;
+  };
+
+  std::shared_ptr<SharedState> sharedState;
+
+  static void processTasks(std::shared_ptr<SharedState> sharedState);
+
+};
+
+template<class Function, class... Args>
+std::future<
+  typename std::result_of<
+    typename std::decay<Function>::type(typename std::decay<Args>::type...)
+  >::type
+> ThreadPoolExecutor::submit(Function &&f, Args &&... args) {
+  // We have to use a shared_ptr because packaged_task is not copyable, so the
+  // lambda expression below could not be put inside the pendingTasks list if
+  // we used packaged_task directly.
+  auto task = std::make_shared<std::packaged_task<decltype(f(args...))()>>(
+    std::bind(std::forward<Function>(f), std::forward<Args>(args)...)
+  );
+  auto future = task->get_future();
+  auto runFunc = [task]() {(*task)();};
+  {
+    std::lock_guard<std::mutex> lock(this->sharedState->mutex);
+    this->sharedState->pendingTasks.push_back(runFunc);
+    if (this->sharedState->idleThreads) {
+      // We decrement idleThreads here instead of in the thread that is woken
+      // up. If we did it the other way round, this method might run again
+      // before the woken-up thread acquires the mutex and we might thus not
+      // create a new thread when we actually have to. By decrementing the
+      // counter here, we can avoid this situation, because decrementing the
+      // counter and waking up a thread happens as an atomic action without
+      // releasing the lock on the mutex in between.
+      --this->sharedState->idleThreads;
+      this->sharedState->wakeUpCv.notify_one();
+    } else {
+      // We create the thread and detach it right away. The thread does not
+      // reference this object, only the shared state, and the latter is
+      // referenced through a shared_ptr, so it will stay alive as long as
+      // there is a thread.
+      std::thread(
+        &ThreadPoolExecutor::processTasks, this->sharedState
+      ).detach();
+    }
+  }
+  return future;
+}
+
+/**
+ * Provides a shared executor instance.
+ *
+ * The returned instance keeps up to four idle threads.
+ */
+ThreadPoolExecutor &sharedThreadPoolExecutor();
+
+} // namespace execute
+} // namespace epics
+
+#endif // EPICS_EXEC_THREAD_POOL_EXECUTOR_H


### PR DESCRIPTION
This PR addresses the issues described in #9.

These issues were caused by two problems (the first one probably being the more important one):

1. When launching an external program, file descriptors that were not needed by this program were not closed. Due to the IOC and the device support code being multi-threaded, this would lead to the file descriptors associated with pipes to leak into the wrong child process. If this child process stayed alive for a long time, this would mean that the thread reading from this file descriptor would stay alive and wait for more input, even though the process for which the pipe was originally intended had long quit.

2. We used `std::async` to launch background threads. The C++ standard does not specify that `std::async` has to create a new thread for each call. It does not even specify that execution has to start right away, so an implementation which only provided one pool thread and used this thread to execute the different tasks passed to `std::async` would be perfectly legal. It is unclear whether the platforms that we target with this device support were actually affected by this, but even if they are not, this could change with future implementations of the C++ standard library.

We address these two problems with two changes:

1. We close all unneeded file descriptors (this is all file descriptors except the ones referring to stdin, stdout, and stderr) after calling `fork` but before calling `execve`. This also has the advantage that the executed program will not get access to file descriptors to which it should not have access, which might have caused other problems as well. In addition to that, we ensure that the three standard file descriptors are always available, binding them to `/dev/null` if no pipe is provided. This is safer than leaving them closed, because the executed program might open files, and if one of the three file descriptors is closed, this file might then get one of these file descriptors, which could lead to this file being accessed accidentally (e.g. when using `printf` in the program).

2. Instead of `std::async`, we use an internal thread pool implementation that does not have an upper bound for the number of available threads. This way, each task will be executed right away instead of potentially being blocked by a different task.